### PR TITLE
fix: Remove href attribute

### DIFF
--- a/packages/react-responsive-pagination/src/index.tsx
+++ b/packages/react-responsive-pagination/src/index.tsx
@@ -36,7 +36,6 @@ function BootstrapPagination({
           <li key={item.key} className={`page-item${item.active ? ' active' : ''}`}>
             <a
               className="page-link"
-              href="#"
               onClick={preventDefault(() => handlePageChange(item.gotoPage))}
               aria-label={item.a11yLabel}
             >


### PR DESCRIPTION
Remove href attribute on `a` tags to prevent the link information to show up in the bottom left corner when hovering a page link:

![Screenshot_6](https://user-images.githubusercontent.com/43232234/147613770-59df91ef-af42-4461-9b84-0dc5c3a807b0.png)

